### PR TITLE
Update compression operation names

### DIFF
--- a/iisbrotli/iisbrotli.cpp
+++ b/iisbrotli/iisbrotli.cpp
@@ -356,12 +356,12 @@ ConvertFlushMode(
 
     switch (operation)
     {
-    case COMPRESSION_OPERATION_PROCESS:
+    case IIS_COMPRESSION_OPERATION_PROCESS:
         break;
-    case COMPRESSION_OPERATION_FLUSH:
+    case IIS_COMPRESSION_OPERATION_FLUSH:
         flushMode = BROTLI_OPERATION_FLUSH;
         break;
-    case COMPRESSION_OPERATION_FINISH:
+    case IIS_COMPRESSION_OPERATION_FINISH:
         flushMode = BROTLI_OPERATION_FINISH;
         break;
     default:

--- a/iisbrotli/stdafx.h
+++ b/iisbrotli/stdafx.h
@@ -31,11 +31,11 @@
 #define DLLEXP extern "C" __declspec(dllexport)
 
 // Constants
-#define COMPRESSION_OPERATION_PROCESS   0
-#define COMPRESSION_OPERATION_FLUSH     1
-#define COMPRESSION_OPERATION_FINISH    2
+#define IIS_COMPRESSION_OPERATION_PROCESS   0
+#define IIS_COMPRESSION_OPERATION_FLUSH     1
+#define IIS_COMPRESSION_OPERATION_FINISH    2
 
-#define BROTLI_PARAMETER_UNSET          -1
+#define BROTLI_PARAMETER_UNSET              -1
 
 // Global variables
 extern INT                              g_intEncoderOp;

--- a/iiszlib/iiszlib.cxx
+++ b/iiszlib/iiszlib.cxx
@@ -452,12 +452,12 @@ ConvertFlushMode(
 
     switch (operation)
     {
-    case COMPRESSION_OPERATION_PROCESS:
+    case IIS_COMPRESSION_OPERATION_PROCESS:
         break;
-    case COMPRESSION_OPERATION_FLUSH:
+    case IIS_COMPRESSION_OPERATION_FLUSH:
         flushMode = Z_SYNC_FLUSH;
         break;
-    case COMPRESSION_OPERATION_FINISH:
+    case IIS_COMPRESSION_OPERATION_FINISH:
         flushMode = Z_FINISH;
         break;
     default:

--- a/iiszlib/stdafx.h
+++ b/iiszlib/stdafx.h
@@ -30,17 +30,17 @@
 #define DLLEXP extern "C" __declspec(dllexport)
 
 // Constants
-#define COMPRESSION_FLAG_DEFLATE        0x00000000
-#define COMPRESSION_FLAG_GZIP           0x00000001
-#define COMPRESSION_FLAG_INVALID        0xFFFFFFFF
+#define COMPRESSION_FLAG_DEFLATE            0x00000000
+#define COMPRESSION_FLAG_GZIP               0x00000001
+#define COMPRESSION_FLAG_INVALID            0xFFFFFFFF
 
-#define COMPRESSION_OPERATION_PROCESS   0
-#define COMPRESSION_OPERATION_FLUSH     1
-#define COMPRESSION_OPERATION_FINISH    2
+#define IIS_COMPRESSION_OPERATION_PROCESS   0
+#define IIS_COMPRESSION_OPERATION_FLUSH     1
+#define IIS_COMPRESSION_OPERATION_FINISH    2
 
-#define ZLIB_DEF_MEM_LEVEL              8   // default memLevel
-#define ZLIB_DEF_WINDOW_BITS            15  // default windowBits, 2^15 ~ 32K window size, RFC 1951
-#define ZLIB_PARAMETER_UNSET            -1
+#define ZLIB_DEF_MEM_LEVEL                  8   // default memLevel
+#define ZLIB_DEF_WINDOW_BITS                15  // default windowBits, 2^15 ~ 32K window size, RFC 1951
+#define ZLIB_PARAMETER_UNSET                -1
 
 // Global variables
 extern INT                              g_intWindowBits;


### PR DESCRIPTION
Update the names of the compression operation constants from COMPRESSION_OPERATION_XXXX to IIS_COMPRESSION_OPERATION_XXXX.

The name will align with the public header httpcompression.h to be published. The original names seem to be too generic and may cause naming collision with other public headers.

Will also need to update the MSDN doc draft.