### PR TITLE
Update readme for the installation path change

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,24 @@ The IIS Compression installer registers `iisbrotli.dll` as the `br` (Brotli) com
 
 ```
 <httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files">
-    <scheme name="br" dll="%windir%\system32\inetsrv\iisbrotli.dll" />
-    <scheme name="gzip" dll="%windir%\system32\inetsrv\iiszlib.dll" />
-    <staticTypes>
-        ...
-    </staticTypes>
+    <scheme name="br" dll="%ProgramFiles%\IIS\IIS Compression\iisbrotli.dll" />
+    <scheme name="gzip" dll="%ProgramFiles%\IIS\IIS Compression\iiszlib.dll" />
     <dynamicTypes>
-        ...
+        <add mimeType="text/*" enabled="true" />
+        <add mimeType="message/*" enabled="true" />
+        <add mimeType="application/x-javascript" enabled="true" />
+        <add mimeType="application/javascript" enabled="true" />
+        <add mimeType="*/*" enabled="false" />
     </dynamicTypes>
+    <staticTypes>
+        <add mimeType="text/*" enabled="true" />
+        <add mimeType="message/*" enabled="true" />
+        <add mimeType="application/javascript" enabled="true" />
+        <add mimeType="application/atom+xml" enabled="true" />
+        <add mimeType="application/xaml+xml" enabled="true" />
+        <add mimeType="image/svg+xml" enabled="true" />
+        <add mimeType="*/*" enabled="false" />
+    </staticTypes>
 </httpCompression>
 ```
 

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -2,11 +2,12 @@ THIRD PARTY NOTICES
 
 This file is based on or incorporates material from the projects listed below (Third Party IP). The original copyright notice and the license under which Microsoft received such Third Party IP, are set forth below. Such licenses and notices are provided for informational purposes only. Microsoft licenses the Third Party IP to you under the licensing terms for the Microsoft product. Microsoft reserves all other rights not expressly granted under this agreement, whether by implication, estoppel or otherwise.
 
+
+**************
 MIT Licensed Files
 The following files were originally licensed under the MIT License. The notices and license text below are provided for informational/attribution purposes only and are not the license terms under which Microsoft distributes this Third Party Software.
 
 
-**************
 Google/brotli
 Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.
 


### PR DESCRIPTION
Since we decided to change the installation path from "inetsrv" to "program files" to avoid binaries being deleted during OS upgrade, update the sample configuration in readme to reflect the change.