### PR TITLE
Fix the issue due to mangled function names exported by x86 dll

### DIFF
--- a/iisbrotli/iisbrotli.cpp
+++ b/iisbrotli/iisbrotli.cpp
@@ -23,7 +23,7 @@ BrotliEncoderOperation ConvertFlushMode(INT operation);
 //
 // Initialize global compression 
 //
-DLLEXP HRESULT WINAPI
+HRESULT WINAPI
 InitCompression(
     VOID
 )
@@ -34,7 +34,7 @@ InitCompression(
 //
 // De-init global compression
 //
-DLLEXP VOID WINAPI
+VOID WINAPI
 DeInitCompression(
     VOID
 )
@@ -45,7 +45,7 @@ DeInitCompression(
 //
 // Reset compression context
 //
-DLLEXP HRESULT WINAPI
+HRESULT WINAPI
 ResetCompression(
     IN OUT PVOID context
 )
@@ -56,7 +56,7 @@ ResetCompression(
 //
 // Create a compression context
 //
-DLLEXP HRESULT WINAPI
+HRESULT WINAPI
 CreateCompression(
     OUT     PVOID *             context,
     IN      ULONG               flags
@@ -96,7 +96,7 @@ Finished:
 //
 // Destroy a compression context
 //
-DLLEXP VOID WINAPI
+VOID WINAPI
 DestroyCompression(
     IN PVOID context
 )
@@ -117,7 +117,7 @@ DestroyCompression(
 //
 // Compress data
 //
-DLLEXP HRESULT WINAPI
+HRESULT WINAPI
 Compress(
     IN OUT  PVOID               context,
     IN      CONST BYTE *        input_buffer,
@@ -232,7 +232,7 @@ Finished:
 //
 // Compress data with a specified flush mode
 //
-DLLEXP HRESULT WINAPI
+HRESULT WINAPI
 Compress2(
     IN OUT  PVOID               context,
     IN      CONST BYTE *        input_buffer,

--- a/iisbrotli/iisbrotli.def
+++ b/iisbrotli/iisbrotli.def
@@ -1,0 +1,14 @@
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; Licensed under the MIT license.
+
+LIBRARY iisbrotli
+
+EXPORTS
+
+    InitCompression
+    DeInitCompression
+    CreateCompression
+    ResetCompression
+    Compress
+    Compress2
+    DestroyCompression

--- a/iisbrotli/iisbrotli.vcxproj
+++ b/iisbrotli/iisbrotli.vcxproj
@@ -41,6 +41,9 @@
       <PreprocessorDefinitions>$(ResourceCompilePreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="iisbrotli.def" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA3EFC47-0ABB-45AD-B672-F1D6066BF62A}</ProjectGuid>
     <RootNamespace>Runtime</RootNamespace>
@@ -67,8 +70,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-      <ModuleDefinitionFile>
-      </ModuleDefinitionFile>
+      <ModuleDefinitionFile>iisbrotli.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/iisbrotli/stdafx.h
+++ b/iisbrotli/stdafx.h
@@ -28,8 +28,6 @@
 #endif
 #include "dbgutil.h"
 
-#define DLLEXP extern "C" __declspec(dllexport)
-
 // Constants
 #define IIS_COMPRESSION_OPERATION_PROCESS   0
 #define IIS_COMPRESSION_OPERATION_FLUSH     1

--- a/iiszlib/iiszlib.cxx
+++ b/iiszlib/iiszlib.cxx
@@ -44,7 +44,7 @@ INT ConvertFlushMode(INT operation);
 //
 // Initialize global compression 
 //
-DLLEXP HRESULT WINAPI
+HRESULT WINAPI
 InitCompression(
     VOID
 )
@@ -55,7 +55,7 @@ InitCompression(
 //
 // De-init global compression
 //
-DLLEXP VOID WINAPI
+VOID WINAPI
 DeInitCompression(
     VOID
 )
@@ -66,7 +66,7 @@ DeInitCompression(
 //
 // Reset compression context
 //
-DLLEXP HRESULT WINAPI
+HRESULT WINAPI
 ResetCompression(
     IN OUT PVOID context
 )
@@ -77,7 +77,7 @@ ResetCompression(
 //
 // Create a compression context
 //
-DLLEXP HRESULT WINAPI
+HRESULT WINAPI
 CreateCompression(
     OUT     PVOID *             context,
     IN      ULONG               flags
@@ -164,7 +164,7 @@ Finished:
 //
 // Destroy a compression context
 //
-DLLEXP VOID WINAPI
+VOID WINAPI
 DestroyCompression(
     IN PVOID context
 )
@@ -184,7 +184,7 @@ DestroyCompression(
 //
 // Compress data
 //
-DLLEXP HRESULT WINAPI
+HRESULT WINAPI
 Compress(
     IN OUT  PVOID               context,
     IN      CONST BYTE *        input_buffer,
@@ -286,7 +286,7 @@ Finished:
 //
 // Compress data with a specified flush mode
 //
-DLLEXP HRESULT WINAPI
+HRESULT WINAPI
 Compress2(
     IN OUT  PVOID               context,
     IN      CONST BYTE *        input_buffer,

--- a/iiszlib/iiszlib.def
+++ b/iiszlib/iiszlib.def
@@ -1,0 +1,14 @@
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; Licensed under the MIT license.
+
+LIBRARY iiszlib
+
+EXPORTS
+
+    InitCompression
+    DeInitCompression
+    CreateCompression
+    ResetCompression
+    Compress
+    Compress2
+    DestroyCompression

--- a/iiszlib/iiszlib.vcxproj
+++ b/iiszlib/iiszlib.vcxproj
@@ -48,6 +48,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>iiszlib.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -68,6 +69,9 @@
     <ProjectReference Include="..\zlib\zlib.vcxproj">
       <Project>{8d460a29-85af-4884-a839-160862a94130}</Project>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="iiszlib.def" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureImportsExist" BeforeTargets="PrepareForBuild">

--- a/iiszlib/stdafx.h
+++ b/iiszlib/stdafx.h
@@ -26,9 +26,6 @@
 #endif
 #include "dbgutil.h"
 
-// Macros
-#define DLLEXP extern "C" __declspec(dllexport)
-
 // Constants
 #define COMPRESSION_FLAG_DEFLATE            0x00000000
 #define COMPRESSION_FLAG_GZIP               0x00000001


### PR DESCRIPTION
The failure only happens with the x86 binaries. IIS compression modules can successfully load the dlls, but fails to get the address of each exported function through GetProcAddress.

After checked the x86 binaries using Dependency Walker, I found mangled names were used by the exported functions only for x86 binaries, but not for x64.

The tricky part is that I explicitly enforced using unmangled names by:
extern "C" __declspec(dllexport) WINAPI
but somehow such enforcement only applied to x64.

Figured out the root cause after extensive search - the second answer in this discussion point it out:
https://stackoverflow.com/questions/538134/exporting-functions-from-a-dll-with-dllexport

Fixed the issue by using def files instead.