### PR TITLE
Compression level validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ korebuild-lock.txt
 *.ipdb
 *.res
 **/RC*
+
+# Generated files
+GeneratedFiles

--- a/iisbrotli/dllmain.cpp
+++ b/iisbrotli/dllmain.cpp
@@ -5,7 +5,9 @@
 
 DECLARE_DEBUG_PRINT_OBJECT2("iisbrotli", DEBUG_FLAGS_ERROR);
 
-INT g_intEncoderOp  = BROTLI_PARAMETER_UNSET;
+INT g_intEncoderOp = BROTLI_PARAMETER_UNSET;
+HANDLE g_hEventLog = NULL;
+BOOL g_fEventRaised = FALSE;
 
 VOID LoadGlobalConfiguration(VOID);
 

--- a/iisbrotli/iisbrotli.cpp
+++ b/iisbrotli/iisbrotli.cpp
@@ -157,7 +157,7 @@ Compress(
     // so only the upper bound needs to be checked.
     if (compression_level > BROTLI_MAX_QUALITY)
     {
-        hr = ReportCompressionLevelOutOfBounds(compression_level, BROTLI_MAX_QUALITY);
+        ReportCompressionLevelOutOfBounds(compression_level, BROTLI_MAX_QUALITY);
         // Ignore any failure from event reporting
         hr = E_INVALIDARG;
         goto Finished;
@@ -284,7 +284,7 @@ Compress2(
     // so only the upper bound needs to be checked.
     if (compression_level > BROTLI_MAX_QUALITY)
     {
-        hr = ReportCompressionLevelOutOfBounds(compression_level, BROTLI_MAX_QUALITY);
+        ReportCompressionLevelOutOfBounds(compression_level, BROTLI_MAX_QUALITY);
         // Ignore any failure from event reporting
         hr = E_INVALIDARG;
         goto Finished;

--- a/iisbrotli/iisbrotli.cpp
+++ b/iisbrotli/iisbrotli.cpp
@@ -142,7 +142,16 @@ Compress(
         hr = E_INVALIDARG;
         goto Finished;
     }
-    else if (pContext->_pState == NULL)
+
+    // IIS schema specifies staticCompressionLevel and dynamicCompressionLevel as uint,
+    // so only the upper bound needs to be checked.
+    if (compression_level > BROTLI_MAX_QUALITY)
+    {
+        hr = E_INVALIDARG;
+        goto Finished;
+    }
+
+    if (pContext->_pState == NULL)
     {
         // Create a BrotliEncoderState instance
         pContext->_pState = BrotliEncoderCreateInstance(NULL,   // alloc_func
@@ -258,7 +267,16 @@ Compress2(
         hr = E_INVALIDARG;
         goto Finished;
     }
-    else if (pContext->_pState == NULL)
+
+    // IIS schema specifies staticCompressionLevel and dynamicCompressionLevel as uint,
+    // so only the upper bound needs to be checked.
+    if (compression_level > BROTLI_MAX_QUALITY)
+    {
+        hr = E_INVALIDARG;
+        goto Finished;
+    }
+
+    if (pContext->_pState == NULL)
     {
         // Create a BrotliEncoderState instance
         pContext->_pState = BrotliEncoderCreateInstance(NULL,   // alloc_func

--- a/iisbrotli/iisbrotli.rc
+++ b/iisbrotli/iisbrotli.rc
@@ -11,3 +11,4 @@
 #define RC_VERSION_LEGAL_COPYRIGHT      "Copyright \251 2018 Microsoft Corporation\0"
 
 #include <bldver.rc>
+#include "./GeneratedFiles/iisbrotli_msg.rc"

--- a/iisbrotli/iisbrotli.vcxproj
+++ b/iisbrotli/iisbrotli.vcxproj
@@ -43,6 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="iisbrotli.def" />
+    <None Include="iisbrotli_msg.mc" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA3EFC47-0ABB-45AD-B672-F1D6066BF62A}</ProjectGuid>
@@ -56,7 +57,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IncludePath>$(ProjectDir)include;$(IIS-Common)version;$(IIS-Common)Include;$(WindowsSDK_IncludePath);$(IncludePath);</IncludePath>
+    <IncludePath>$(ProjectDir)include;$(ProjectDir)GeneratedFiles;$(IIS-Common)version;$(IIS-Common)Include;$(WindowsSDK_IncludePath);$(IncludePath);</IncludePath>
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>
@@ -87,4 +88,12 @@
   </Target>
   <Import Project="$(UserProfile)\.nuget\packages\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.targets" Condition="Exists('$(UserProfile)\.nuget\packages\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.targets')" />
   <Import Project="$(IIS-Common)build\copy-outputs.targets" Condition="Exists('$(IIS-Common)build\copy-outputs.targets')" />
+  <Target Name="GenerateIISBrotliMsgResource" AfterTargets="PrepareForBuild">
+    <Message Text="Generating iisbrotli_msg.h and iisbrotli_msg.rc via the mc.exe util">
+    </Message>
+    <Exec Condition="!Exists('$(ProjectDir)GeneratedFiles')" Command="mkdir $(ProjectDir)GeneratedFiles">
+    </Exec>
+    <Exec Command="mc.exe $(ProjectDir)iisbrotli_msg.mc -h $(ProjectDir)GeneratedFiles -r $(ProjectDir)GeneratedFiles">
+    </Exec>
+  </Target>
 </Project>

--- a/iisbrotli/iisbrotli_msg.mc
+++ b/iisbrotli/iisbrotli_msg.mc
@@ -1,0 +1,23 @@
+;/*++
+;  Copyright (c) Microsoft Corporation. All rights reserved.
+;  Licensed under the MIT license.
+;--*/
+;
+;#ifndef _IISBROTLI_MSG_H_
+;#define _IISBROTLI_MSG_H_
+;
+
+SeverityNames=(Success=0x0
+               Informational=0x1
+               Warning=0x2
+               Error=0x3
+              )
+
+Messageid=1000 Severity=Error SymbolicName=BROTLI_COMPRESSION_LEVEL_OUT_OF_BOUNDS
+Language=English
+The Brotli compression level '%1' is larger than the maximum allowed value '%2'.
+.
+
+;
+;#endif     // _IISBROTLI_MSG_H_
+;

--- a/iisbrotli/stdafx.h
+++ b/iisbrotli/stdafx.h
@@ -13,6 +13,7 @@
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 // Windows Header Files:
 #include <windows.h>
+#include <stdlib.h>
 
 // Brotli Header Files
 #include "port.h"
@@ -27,6 +28,7 @@
     #endif
 #endif
 #include "dbgutil.h"
+#include "iisbrotli_msg.h"
 
 // Constants
 #define IIS_COMPRESSION_OPERATION_PROCESS   0
@@ -35,5 +37,9 @@
 
 #define BROTLI_PARAMETER_UNSET              -1
 
+#define COMPRESSION_LEVEL_BUFFER_LENGTH     33
+
 // Global variables
 extern INT                              g_intEncoderOp;
+extern HANDLE                           g_hEventLog;
+extern BOOL                             g_fEventRaised;

--- a/iiszlib/dllmain.cpp
+++ b/iiszlib/dllmain.cpp
@@ -9,6 +9,8 @@ INT         g_intWindowBits = ZLIB_PARAMETER_UNSET;
 INT         g_intMemLevel   = ZLIB_PARAMETER_UNSET;
 INT         g_intFlushMode  = ZLIB_PARAMETER_UNSET;
 BOOL        g_fEnableZlibDeflate = FALSE;
+HANDLE      g_hEventLog     = NULL;
+BOOL        g_fEventRaised  = FALSE;
 
 VOID LoadGlobalConfiguration(VOID);
 

--- a/iiszlib/iiszlib.cxx
+++ b/iiszlib/iiszlib.cxx
@@ -221,7 +221,7 @@ Compress(
     // so only the upper bound needs to be checked.
     if (compression_level > Z_BEST_COMPRESSION)
     {
-        hr = ReportCompressionLevelOutOfBounds(compression_level, Z_BEST_COMPRESSION);
+        ReportCompressionLevelOutOfBounds(compression_level, Z_BEST_COMPRESSION);
         // Ignore any failure from event reporting
         hr = E_INVALIDARG;
         goto Finished;
@@ -335,7 +335,7 @@ Compress2(
     // so only the upper bound needs to be checked.
     if (compression_level > Z_BEST_COMPRESSION)
     {
-        hr = ReportCompressionLevelOutOfBounds(compression_level, Z_BEST_COMPRESSION);
+        ReportCompressionLevelOutOfBounds(compression_level, Z_BEST_COMPRESSION);
         // Ignore any failure from event reporting
         hr = E_INVALIDARG;
         goto Finished;

--- a/iiszlib/iiszlib.cxx
+++ b/iiszlib/iiszlib.cxx
@@ -206,7 +206,16 @@ Compress(
         hr = E_INVALIDARG;
         goto Finished;
     }
-    else if (pContext->_fInitialized == FALSE)
+
+    // IIS schema specifies staticCompressionLevel and dynamicCompressionLevel as uint,
+    // so only the upper bound needs to be checked.
+    if (compression_level > Z_BEST_COMPRESSION)
+    {
+        hr = E_INVALIDARG;
+        goto Finished;
+    }
+
+    if (pContext->_fInitialized == FALSE)
     {
         ret = deflateInit2(&pContext->_strm,            // strm
                            compression_level,           // level
@@ -309,7 +318,16 @@ Compress2(
         hr = E_INVALIDARG;
         goto Finished;
     }
-    else if (pContext->_fInitialized == FALSE)
+
+    // IIS schema specifies staticCompressionLevel and dynamicCompressionLevel as uint,
+    // so only the upper bound needs to be checked.
+    if (compression_level > Z_BEST_COMPRESSION)
+    {
+        hr = E_INVALIDARG;
+        goto Finished;
+    }
+
+    if (pContext->_fInitialized == FALSE)
     {
         ret = deflateInit2(&pContext->_strm,            // strm
                            compression_level,           // level

--- a/iiszlib/iiszlib.rc
+++ b/iiszlib/iiszlib.rc
@@ -11,3 +11,4 @@
 #define RC_VERSION_LEGAL_COPYRIGHT      "Copyright \251 2018 Microsoft Corporation\0"
 
 #include <bldver.rc>
+#include "./GeneratedFiles/iiszlib_msg.rc"

--- a/iiszlib/iiszlib.vcxproj
+++ b/iiszlib/iiszlib.vcxproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <IncludePath>$(ProjectDir)include;$(IIS-Common)version;$(IIS-Common)Include;$(WindowsSDK_IncludePath);$(IncludePath);</IncludePath>
+    <IncludePath>$(ProjectDir)include;$(ProjectDir)GeneratedFiles;$(IIS-Common)version;$(IIS-Common)Include;$(WindowsSDK_IncludePath);$(IncludePath);</IncludePath>
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="iiszlib.def" />
+    <None Include="iiszlib_msg.mc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="EnsureImportsExist" BeforeTargets="PrepareForBuild">
@@ -87,4 +88,12 @@
   </Target>
   <Import Project="$(UserProfile)\.nuget\packages\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.targets" Condition="Exists('$(UserProfile)\.nuget\packages\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.targets')" />
   <Import Project="$(IIS-Common)build\copy-outputs.targets" Condition="Exists('$(IIS-Common)build\copy-outputs.targets')" />
+  <Target Name="GenerateIISZlibMsgResource" AfterTargets="PrepareForBuild">
+    <Message Text="Generating iiszlib_msg.h and iiszlib_msg.rc via the mc.exe util">
+    </Message>
+    <Exec Condition="!Exists('$(ProjectDir)GeneratedFiles')" Command="mkdir $(ProjectDir)GeneratedFiles">
+    </Exec>
+    <Exec Command="mc.exe $(ProjectDir)iiszlib_msg.mc -h $(ProjectDir)GeneratedFiles -r $(ProjectDir)GeneratedFiles">
+    </Exec>
+  </Target>
 </Project>

--- a/iiszlib/iiszlib_msg.mc
+++ b/iiszlib/iiszlib_msg.mc
@@ -1,0 +1,23 @@
+;/*++
+;  Copyright (c) Microsoft Corporation. All rights reserved.
+;  Licensed under the MIT license.
+;--*/
+;
+;#ifndef _IISZLIB_MSG_H_
+;#define _IISZLIB_MSG_H_
+;
+
+SeverityNames=(Success=0x0
+               Informational=0x1
+               Warning=0x2
+               Error=0x3
+              )
+
+Messageid=1000 Severity=Error SymbolicName=ZLIB_COMPRESSION_LEVEL_OUT_OF_BOUNDS
+Language=English
+The Zlib compression level '%1' is larger than the maximum allowed value '%2'.
+.
+
+;
+;#endif     // _IISBROTLI_MSG_H_
+;

--- a/iiszlib/stdafx.h
+++ b/iiszlib/stdafx.h
@@ -13,6 +13,7 @@
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 // Windows Header Files:
 #include <windows.h>
+#include <stdlib.h>
 
 // zlib Header Files:
 #include "zlib.h"
@@ -25,6 +26,7 @@
     #endif
 #endif
 #include "dbgutil.h"
+#include "iiszlib_msg.h"
 
 // Constants
 #define COMPRESSION_FLAG_DEFLATE            0x00000000
@@ -39,8 +41,12 @@
 #define ZLIB_DEF_WINDOW_BITS                15  // default windowBits, 2^15 ~ 32K window size, RFC 1951
 #define ZLIB_PARAMETER_UNSET                -1
 
+#define COMPRESSION_LEVEL_BUFFER_LENGTH     33
+
 // Global variables
 extern INT                              g_intWindowBits;
 extern INT                              g_intMemLevel;
 extern INT                              g_intFlushMode;
 extern BOOL                             g_fEnableZlibDeflate;
+extern HANDLE                           g_hEventLog;
+extern BOOL                             g_fEventRaised;


### PR DESCRIPTION
The PR is made to address: https://github.com/Microsoft/IIS.Compression/issues/15

iiszlib.dll has maximum allowable compression level 9, while the inbox gzip.dll has maximum level 10. This can not only cause confusion, but also zlib library directly crashes if the passed-in compression level is larger than 9. It would be extremely hard for users to figure out the root cause once the crash happens.

**Main changes in the PR:**
1. Added compression level validation for both iiszlib and iisbrotli. If the compression level is out-of-bounds, IIS will simply return 500.19 to indicate a configuration error, and ask to check event log.
2. Upon failure, both compression schemes will fire an event to application event log to indicate the current compression level VS the maximum value allowed. Each scheme will only fire one event per w3wp.exe lifetime to avoid spamming the event logs.

**Other changes:**
- Updated the submodule reference to the latest IIS-Common
- Updated .gitignore to neglect the .h, .rc files generated by mc.exe.

**Future changes:**

To let event viewer properly parse the message data, we need to set the following registries:

**HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\IIS Zlib:**
EventMessageFile (REG_EXPAND_SZ): C:\Program Files\IIS\IIS Compression\iiszlib.dll
TypesSupported (REG_DWORD): 7

**HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\IIS Brotli:**
EventMessageFile (REG_EXPAND_SZ): C:\Program Files\IIS\IIS Compression\iisbrotli.dll
TypesSupported (REG_DWORD): 7

We need to update the installer of IIS Compression to write these registries.