### PR TITLE
Update event source name to align with the installer

### DIFF
--- a/iisbrotli/iisbrotli.cpp
+++ b/iisbrotli/iisbrotli.cpp
@@ -30,7 +30,7 @@ InitCompression(
 )
 {
     g_hEventLog = RegisterEventSource(NULL,
-                                      L"IIS Brotli");
+                                      IISBROTLI_EVENT_SOURCE_NAME);
 
     // Ignore the failure from RegisterEventSource
     return S_OK;

--- a/iisbrotli/iisbrotli.vcxproj
+++ b/iisbrotli/iisbrotli.vcxproj
@@ -72,6 +72,8 @@
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>iisbrotli.def</ModuleDefinitionFile>
+      <GenerateDebugInformation Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">DebugFull</GenerateDebugInformation>
+      <GenerateDebugInformation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">DebugFull</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/iisbrotli/stdafx.h
+++ b/iisbrotli/stdafx.h
@@ -39,6 +39,8 @@
 
 #define COMPRESSION_LEVEL_BUFFER_LENGTH     33
 
+#define IISBROTLI_EVENT_SOURCE_NAME         L"IISBrotli"
+
 // Global variables
 extern INT                              g_intEncoderOp;
 extern HANDLE                           g_hEventLog;

--- a/iiszlib/iiszlib.cxx
+++ b/iiszlib/iiszlib.cxx
@@ -51,7 +51,7 @@ InitCompression(
 )
 {
     g_hEventLog = RegisterEventSource(NULL,
-                                      L"IIS Zlib");
+                                      IISZLIB_EVENT_SOURCE_NAME);
 
     // Ignore the failure from RegisterEventSource
     return S_OK;

--- a/iiszlib/iiszlib.vcxproj
+++ b/iiszlib/iiszlib.vcxproj
@@ -49,6 +49,8 @@
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>iiszlib.def</ModuleDefinitionFile>
+      <GenerateDebugInformation Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">DebugFull</GenerateDebugInformation>
+      <GenerateDebugInformation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">DebugFull</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/iiszlib/stdafx.h
+++ b/iiszlib/stdafx.h
@@ -43,6 +43,8 @@
 
 #define COMPRESSION_LEVEL_BUFFER_LENGTH     33
 
+#define IISZLIB_EVENT_SOURCE_NAME           L"IISZlib"
+
 // Global variables
 extern INT                              g_intWindowBits;
 extern INT                              g_intMemLevel;


### PR DESCRIPTION
Realized that the installer of IIS Compression specifies project names as "IISZlib" and "IISBrotli" without a space in between. Updated the event source name to align with this convention so that we don't need to hard coded another name for the registry in the wix.

Also updated the project files and configured linker to emit full symbols even for debug builds.