### PR TITLE
Build pipeline template: publish sources as an artifact

### DIFF
--- a/.pipelines/iis.compression.build.dev.yml
+++ b/.pipelines/iis.compression.build.dev.yml
@@ -9,4 +9,4 @@ jobs:
     productMajor: 1
     productMinor: 0
     signType: 'test'
-    publishArtifactInstaller: 'true'
+    publishArtifactInstallers: 'true'

--- a/.pipelines/iis.compression.build.official.yml
+++ b/.pipelines/iis.compression.build.official.yml
@@ -10,4 +10,4 @@ jobs:
     productMinor: 0
     signType: 'real'
     indexSourcesAndPublishSymbols: 'true'
-    publishArtifactInstaller: 'true'
+    publishArtifactInstallers: 'true'

--- a/.pipelines/iis.compression.build.official.yml
+++ b/.pipelines/iis.compression.build.official.yml
@@ -11,3 +11,4 @@ jobs:
     signType: 'real'
     indexSourcesAndPublishSymbols: 'true'
     publishArtifactInstallers: 'true'
+    publishArtifactSources: 'true'

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -10,7 +10,7 @@ parameters:
   teamName: 'IIS'
   indexSourcesAndPublishSymbols: 'false'
   publishArtifactInstallers: 'false'
-  publishArtifactSources: 'true'
+  publishArtifactSources: 'false'
 
 jobs:
 - job: build

--- a/.pipelines/templates/build.yml
+++ b/.pipelines/templates/build.yml
@@ -9,7 +9,8 @@ parameters:
   signingIdentity: 'Microsoft'
   teamName: 'IIS'
   indexSourcesAndPublishSymbols: 'false'
-  publishArtifactInstaller: 'false'
+  publishArtifactInstallers: 'false'
+  publishArtifactSources: 'true'
 
 jobs:
 - job: build
@@ -29,6 +30,14 @@ jobs:
   - checkout: self
     clean: true
     submodules: recursive
+
+  - ${{ if eq(parameters.publishArtifactSources, 'true') }}:
+    - task: CopyFiles@2
+      displayName: 'Copy Sources'
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)'
+        Contents: '**'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)\Sources'
 
   - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
     displayName: 'Install Signing Plugin'
@@ -105,7 +114,7 @@ jobs:
       Contents: '**\x64\**\*pdb'
       TargetFolder: '$(Build.ArtifactStagingDirectory)\Symbols\x64'
 
-  - ${{ if eq(parameters.publishArtifactInstaller, 'true') }}:
+  - ${{ if eq(parameters.publishArtifactInstallers, 'true') }}:
     - task: CopyFiles@2
       displayName: 'Copy Installers x86'
       inputs:
@@ -113,7 +122,7 @@ jobs:
         Contents: '**\*.msi'
         TargetFolder: '$(Build.ArtifactStagingDirectory)\Installers\x86'
 
-  - ${{ if eq(parameters.publishArtifactInstaller, 'true') }}:
+  - ${{ if eq(parameters.publishArtifactInstallers, 'true') }}:
     - task: CopyFiles@2
       displayName: 'Copy Installers x64'
       inputs:
@@ -141,9 +150,16 @@ jobs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)\Symbols'
       ArtifactName: Symbols
 
-  - ${{ if eq(parameters.publishArtifactInstaller, 'true') }}:
+  - ${{ if eq(parameters.publishArtifactInstallers, 'true') }}:
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: Installers'
       inputs:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)\Installers'
         ArtifactName: Installers
+
+  - ${{ if eq(parameters.publishArtifactSources, 'true') }}:
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: Sources'
+      inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)\Sources'
+        ArtifactName: Sources


### PR DESCRIPTION
For the release pipeline to archive the sources for official builds, the corresponding build pipeline must publish sources as a separate artifact.

The change simply inserts a "CopyFile" task at the beginning of the pipeline (before any obj, dll, etc get generated) so that it can copy the freshly cloned sources to a separate artifact staging folder. Then a "PublishBuildArtifacts" task is added to publish the sources as an artifact.

Once this PR is in, we can simply update the release pipeline by downloading the Sources artifact to our archive file share.