### PR TITLE
Update whiteListPathForAuthenticodeSign for the official build

### DIFF
--- a/.pipelines/iis.compression.build.official.yml
+++ b/.pipelines/iis.compression.build.official.yml
@@ -19,3 +19,4 @@ jobs:
     indexSourcesAndPublishSymbols: 'true'
     publishArtifactInstallers: 'true'
     publishArtifactSources: 'true'
+    whiteListPathForAuthenticodeSign: '$(Build.SourcesDirectory)\IIS-Common\.azure\templates\no_authenticode.txt'

--- a/.pipelines/iis.compression.build.official.yml
+++ b/.pipelines/iis.compression.build.official.yml
@@ -19,4 +19,4 @@ jobs:
     indexSourcesAndPublishSymbols: 'true'
     publishArtifactInstallers: 'true'
     publishArtifactSources: 'true'
-    whiteListPathForAuthenticodeSign: '$(Build.SourcesDirectory)\IIS-Common\.azure\templates\no_authenticode.txt'
+    whiteListPathForAuthenticodeSign: '..\IIS-Common\.azure\templates\no_authenticode.txt'

--- a/.pipelines/iis.compression.build.official.yml
+++ b/.pipelines/iis.compression.build.official.yml
@@ -5,6 +5,7 @@ resources:
     - repository: MicrosoftIISCommon
       type: github
       name: Microsoft/IIS.Common
+      ref: 'refs/heads/bangbingsyb/signverify-whitelist'
       endpoint: GitHub-IIS-PAT
 
 jobs:
@@ -19,4 +20,4 @@ jobs:
     indexSourcesAndPublishSymbols: 'true'
     publishArtifactInstallers: 'true'
     publishArtifactSources: 'true'
-    whiteListPathForAuthenticodeSign: '..\IIS-Common\.azure\templates\no_authenticode.txt'
+    whiteListPathForAuthenticodeSign: '$(Build.SourcesDirectory)\IIS-Common\.azure\templates\no_authenticode.txt'

--- a/.pipelines/iis.compression.build.official.yml
+++ b/.pipelines/iis.compression.build.official.yml
@@ -5,7 +5,6 @@ resources:
     - repository: MicrosoftIISCommon
       type: github
       name: Microsoft/IIS.Common
-      ref: 'refs/heads/bangbingsyb/signverify-whitelist'
       endpoint: GitHub-IIS-PAT
 
 jobs:

--- a/.pipelines/templates/no_authenticode.txt
+++ b/.pipelines/templates/no_authenticode.txt
@@ -1,2 +1,0 @@
-**\*.cab.cab
-**\*wixuiwixca.dll


### PR DESCRIPTION
- Remove the local whitelist for signing verification.
- Reference the one from IIS.Common submodule.