### PR TITLE
Update error handling for out-of-bound compression level

### DIFF
--- a/iisbrotli/iisbrotli.cpp
+++ b/iisbrotli/iisbrotli.cpp
@@ -157,10 +157,10 @@ Compress(
     // so only the upper bound needs to be checked.
     if (compression_level > BROTLI_MAX_QUALITY)
     {
-        ReportCompressionLevelOutOfBounds(compression_level, BROTLI_MAX_QUALITY);
         // Ignore any failure from event reporting
-        hr = E_INVALIDARG;
-        goto Finished;
+        ReportCompressionLevelOutOfBounds(compression_level, BROTLI_MAX_QUALITY);
+
+        compression_level = BROTLI_MAX_QUALITY;
     }
 
     if (pContext->_pState == NULL)
@@ -284,10 +284,10 @@ Compress2(
     // so only the upper bound needs to be checked.
     if (compression_level > BROTLI_MAX_QUALITY)
     {
-        ReportCompressionLevelOutOfBounds(compression_level, BROTLI_MAX_QUALITY);
         // Ignore any failure from event reporting
-        hr = E_INVALIDARG;
-        goto Finished;
+        ReportCompressionLevelOutOfBounds(compression_level, BROTLI_MAX_QUALITY);
+
+        compression_level = BROTLI_MAX_QUALITY;
     }
 
     if (pContext->_pState == NULL)
@@ -444,7 +444,7 @@ ReportCompressionLevelOutOfBounds(
     apsz[1] = bufMaxLevel;
 
     fReport = ReportEvent(g_hEventLog,                // hEventLog
-                          EVENTLOG_ERROR_TYPE,        // wType
+                          EVENTLOG_WARNING_TYPE,      // wType
                           0,                          // wCategory
                           BROTLI_COMPRESSION_LEVEL_OUT_OF_BOUNDS,     // dwEventID
                           NULL,                       // lpUserSid

--- a/iisbrotli/iisbrotli_msg.mc
+++ b/iisbrotli/iisbrotli_msg.mc
@@ -13,9 +13,9 @@ SeverityNames=(Success=0x0
                Error=0x3
               )
 
-Messageid=1000 Severity=Error SymbolicName=BROTLI_COMPRESSION_LEVEL_OUT_OF_BOUNDS
+Messageid=1000 Severity=Warning SymbolicName=BROTLI_COMPRESSION_LEVEL_OUT_OF_BOUNDS
 Language=English
-The Brotli compression level '%1' is larger than the maximum allowed value '%2'.
+The Brotli compression level '%1' is larger than the maximum allowed value '%2' and has been reset to '%2'.
 .
 
 ;

--- a/iiszlib/iiszlib.cxx
+++ b/iiszlib/iiszlib.cxx
@@ -221,10 +221,10 @@ Compress(
     // so only the upper bound needs to be checked.
     if (compression_level > Z_BEST_COMPRESSION)
     {
-        ReportCompressionLevelOutOfBounds(compression_level, Z_BEST_COMPRESSION);
         // Ignore any failure from event reporting
-        hr = E_INVALIDARG;
-        goto Finished;
+        ReportCompressionLevelOutOfBounds(compression_level, Z_BEST_COMPRESSION);
+
+        compression_level = Z_BEST_COMPRESSION;
     }
 
     if (pContext->_fInitialized == FALSE)
@@ -335,10 +335,10 @@ Compress2(
     // so only the upper bound needs to be checked.
     if (compression_level > Z_BEST_COMPRESSION)
     {
-        ReportCompressionLevelOutOfBounds(compression_level, Z_BEST_COMPRESSION);
         // Ignore any failure from event reporting
-        hr = E_INVALIDARG;
-        goto Finished;
+        ReportCompressionLevelOutOfBounds(compression_level, Z_BEST_COMPRESSION);
+
+        compression_level = Z_BEST_COMPRESSION;
     }
 
     if (pContext->_fInitialized == FALSE)
@@ -540,7 +540,7 @@ ReportCompressionLevelOutOfBounds(
     apsz[1] = bufMaxLevel;
 
     fReport = ReportEvent(g_hEventLog,                // hEventLog
-                          EVENTLOG_ERROR_TYPE,        // wType
+                          EVENTLOG_WARNING_TYPE,      // wType
                           0,                          // wCategory
                           ZLIB_COMPRESSION_LEVEL_OUT_OF_BOUNDS,     // dwEventID
                           NULL,                       // lpUserSid

--- a/iiszlib/iiszlib_msg.mc
+++ b/iiszlib/iiszlib_msg.mc
@@ -13,9 +13,9 @@ SeverityNames=(Success=0x0
                Error=0x3
               )
 
-Messageid=1000 Severity=Error SymbolicName=ZLIB_COMPRESSION_LEVEL_OUT_OF_BOUNDS
+Messageid=1000 Severity=Warning SymbolicName=ZLIB_COMPRESSION_LEVEL_OUT_OF_BOUNDS
 Language=English
-The Zlib compression level '%1' is larger than the maximum allowed value '%2'.
+The Zlib compression level '%1' is larger than the maximum allowed value '%2' and has been reset to '%2'.
 .
 
 ;


### PR DESCRIPTION
This is expected as the last change I'd like to make before the new release.

After rethink the current error handling, I think it might be better to not fail the requests at all upon out-of-bound compression level. We already raise event to event log to notify the misconfiguration. Automatically correcting the level in runtime seems to be more user friendly.