### PR TITLE
Update project files for VS2022

### DIFF
--- a/.pipelines/iis.compression.build.dev.yml
+++ b/.pipelines/iis.compression.build.dev.yml
@@ -19,7 +19,7 @@ resources:
 jobs:
 - template: .azure\templates\build.yml@MicrosoftIISCommon
   parameters:
-    agentPoolName: 'VSEngSS-MicroBuild2019-1ES'
+    agentPoolName: 'VSEngSS-MicroBuild2022-1ES'
     solution: '**\Compression.sln'
     restoreSolution: 'Compression.sln;IIS-Setup/IIS-Setup.sln'
     productMajor: 1

--- a/.pipelines/iis.compression.build.official.yml
+++ b/.pipelines/iis.compression.build.official.yml
@@ -13,7 +13,7 @@ resources:
 jobs:
 - template: .azure\templates\build.yml@MicrosoftIISCommon
   parameters:
-    agentPoolName: 'VSEngSS-MicroBuild2019-1ES'
+    agentPoolName: 'VSEngSS-MicroBuild2022-1ES'
     solution: '**\Compression.sln'
     restoreSolution: 'Compression.sln;IIS-Setup/IIS-Setup.sln'
     productMajor: 1

--- a/CustomAction/iiscompressionCA.vcxproj
+++ b/CustomAction/iiscompressionCA.vcxproj
@@ -64,7 +64,7 @@
   <PropertyGroup>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>

--- a/brotli/brotli.vcxproj
+++ b/brotli/brotli.vcxproj
@@ -117,7 +117,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>

--- a/iisbrotli/iisbrotli.vcxproj
+++ b/iisbrotli/iisbrotli.vcxproj
@@ -49,12 +49,12 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CA3EFC47-0ABB-45AD-B672-F1D6066BF62A}</ProjectGuid>
     <RootNamespace>Runtime</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>

--- a/iiszlib/iiszlib.vcxproj
+++ b/iiszlib/iiszlib.vcxproj
@@ -25,12 +25,12 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{57619DE0-503C-4758-97BC-5AFA0A029BFA}</ProjectGuid>
     <RootNamespace>Runtime</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>

--- a/zlib/zlib.vcxproj
+++ b/zlib/zlib.vcxproj
@@ -28,7 +28,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>


### PR DESCRIPTION
To enable CodeQL for IIS.Compression, we need to update the IIS.Common submodule to the latest commit.
However due to other changes that have happened in IIS.Common, this means we also need to build IIS.Compression with VS2022.